### PR TITLE
us(182877): fix silent fail on client error

### DIFF
--- a/scripts/start-build
+++ b/scripts/start-build
@@ -166,8 +166,6 @@ if [ ${WAIT_FOR_CODEBUILD} = "true" ]; then
       has_events=true
     else
       echo "Waiting for logs"
-      sleep 10
-      fetch_logs
     fi
 
     # keep previous nextForwardToken value


### PR DESCRIPTION
@ebarault 
J'ai remarqué qu'une boucle se formait à ce niveau, car lorsque des erreurs de provisionning se produisent, aucun log n'est remonté dans le log group. J'ai effectué des tests via la console, et aucun log n'était remonté lors des erreurs de provisionning.

Cela explique la boucle qui se forme. La boucle empêche d'atteindre le bloc # Get build result.

Ce bloc affiche l'état de chaque étape et précise explicitement l'étape qui échoue avec un message d'erreur.

En supprimant l'appel de la fonction à ce niveau la boucle n'existe plus et on peut desormais avoir les logs lorsque les erreurs de provisionning apparait mais aussi tout autre logs en rapport avec l'exécution du codebuild.